### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ High Performance Computing for Weather and Climate Course
 
 [Day 3](https://github.com/ofuhrer/HPC4WC/tree/master/day3) Distributed memory parallelism, MPI, message passing, point-to-point communication, deadlock, non-blocking communication, gather/scatter operation, domain decomposition, halo-points and halo-updates
 
-[Day 4](https://github.com/ofuhrer/HPC4WC/tree/master/day4) Graphics Processing Units, hybrid node architecture, high-level GPU programming with CuPy, data managment and offload model, synchronization, vectorization, platform agnostic code, low-level GPU programming
+[Day 4](https://github.com/ofuhrer/HPC4WC/tree/master/day4) Graphics Processing Units, hybrid node architecture, high-level GPU programming with CuPy, data management and offload model, synchronization, vectorization, platform agnostic code, low-level GPU programming
 
 [Day 5](https://github.com/ofuhrer/HPC4WC/tree/master/day5) High-level programming models, domain-specific language, GT4Py, performance portability, abstraction for stencil computations
 


### PR DESCRIPTION
## Summary
- fix typo in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848031268b083258ecb5947b1f466ab